### PR TITLE
Support complex Glob pattern

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
 
         EXCLUDE_GLOB=""
         if [ -n "${{ inputs.exclude-glob }}" ]; then
-          EXCLUDE_GLOB="-exclude-glob=${{ inputs.exclude-glob }}"
+          EXCLUDE_GLOB="-exclude-glob='${{ inputs.exclude-glob }}'"
         fi
 
         TESTS=$(./split_tests ${SPLIT_BY} -split-index=${{ inputs.split-index }} -split-total=${{ inputs.split-total }} -glob='${{ inputs.glob }}' ${EXCLUDE_GLOB})

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
           EXCLUDE_GLOB="-exclude-glob=${{ inputs.exclude-glob }}"
         fi
 
-        TESTS=$(./split_tests ${SPLIT_BY} -split-index=${{ inputs.split-index }} -split-total=${{ inputs.split-total }} -glob=${{ inputs.glob }} ${EXCLUDE_GLOB})
+        TESTS=$(./split_tests ${SPLIT_BY} -split-index=${{ inputs.split-index }} -split-total=${{ inputs.split-total }} -glob='${{ inputs.glob }}' ${EXCLUDE_GLOB})
 
         echo $TESTS
 


### PR DESCRIPTION
### Purpose
Without quotes complex glob patterns like `test/{controllers,routes,models,modules}/**/*.{js,ts}` can not be parsed.