### PR TITLE
Replace deprecated set-output command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
 
         echo $TESTS
 
-        echo "::set-output name=test-suite::$(echo $TESTS)"
+        echo "test-suite=${TESTS}" >> $GITHUB_OUTPUT          
       shell: bash
 branding:
   icon: shuffle


### PR DESCRIPTION
As referred in:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The set-output command is deprecated and can be replaced with $GITHUB_OUTPUT

The behavior remains the same.