### PR TITLE
Exclude Glob doesn't exclude

### DIFF
--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -47,6 +47,33 @@ jobs:
           split-index: 0
       - run: echo "The output test suite is ${{ steps.split-tests.outputs.test-suite }}"
 
+  smoke-test-exclude-glob:
+    runs-on: ubuntu-latest
+    name: Smoke Test Exclude Glob
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: eliotsykes/rspec-rails-examples
+          path: examples/
+      - uses: ./
+        id: split-tests
+        name: Run this action
+        with:
+          glob: examples/spec/**/*_spec.rb
+          exclude-glob: examples/spec/api/**/t*_spec.rb
+          split-total: 5
+          split-index: 0
+      - run: echo "The output test suite is ${{ steps.split-tests.outputs.test-suite }}"
+      - run: |
+          if echo "${{ steps.split-tests.outputs.test-suite }}" | grep -q '/token_spec.rb'; then
+            echo "token_spec.rb is included in the test-suite, failing the job."
+            exit 1
+          else
+            echo "token_spec.rb is not included in the test-suite, proceeding."
+          fi
+        name: Check for token_spec.rb
+
   smoke-test-line:
     runs-on: ubuntu-latest
     name: Smoke Test Line Count

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
 
         EXCLUDE_GLOB=""
         if [ -n "${{ inputs.exclude-glob }}" ]; then
-          EXCLUDE_GLOB="-exclude-glob='${{ inputs.exclude-glob }}'"
+          EXCLUDE_GLOB="-exclude-glob=${{ inputs.exclude-glob }}"
         fi
 
         TESTS=$(./split_tests ${SPLIT_BY} -split-index=${{ inputs.split-index }} -split-total=${{ inputs.split-total }} -glob='${{ inputs.glob }}' ${EXCLUDE_GLOB})


### PR DESCRIPTION
## Whats going on?
Well I noticed when I use glob and exclude-glob while the exclude glob looks correct the tests are not excluded

## What I expect?
When the exclude a glob the tests will be excluded

## What have I done
I wrote a test to prove that with glob and exclude-glob the excluded test is still present in the expected test suites.

Fixes #8

@scruplelesswizard Got this working on my fork since tests require approval here https://github.com/ninjapanzer/split-tests/pull/1